### PR TITLE
Upgrade to 0.0.0/composer-include-files.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "symfony/property-access": "^5.1"
     },
     "require-dev": {
-        "funkjedi/composer-include-files": "^1.0",
+        "0.0.0/composer-include-files": "^1.6",
         "laravel/legacy-factories": "^1.1",
         "mockery/mockery": "^1.3|^1.4.2",
         "orchestra/database": "^5.0|^6.0",
@@ -56,5 +56,10 @@
         ]
     },
     "minimum-stability": "dev",
-    "prefer-stable": true
+    "prefer-stable": true,
+    "config": {
+        "allow-plugins": {
+            "0.0.0/composer-include-files": true
+        }
+    }
 }


### PR DESCRIPTION
This is a drop-in replacement for funkjedi/composer-include-files.

It is an actively maintained fork with a lot of features and bug fixes.